### PR TITLE
BRISTECH-90 added comms service to cluster

### DIFF
--- a/dataCenter/singleEcs.json
+++ b/dataCenter/singleEcs.json
@@ -63,12 +63,36 @@
                 ]
             }
         },
-        "service": {
+        "speakerService": {
             "Type": "AWS::ECS::Service",
             "Properties" : {
                 "Cluster": {"Ref": "speakersCluster"},
                 "DesiredCount": "1",
                 "TaskDefinition" : {"Ref":"speakersTaskDefinition"}
+            }
+        },
+         "speakerCommsTaskDefinition": {
+            "Type": "AWS::ECS::TaskDefinition",
+            "Properties" : {
+                "ContainerDefinitions" : [
+                    {
+                        "Name" : "speakers",
+                        "Cpu" : "1",
+                        "Image" : "bristechsrm/speaker-comms:latest",
+                        "Memory" : "300",
+                        "PortMappings" : [
+                            {"HostPort" : 8080, "ContainerPort" : 8080, "Protocol" : "tcp"}
+                        ]
+                    }
+                ]
+            }
+        },
+        "speakerCommsService": {
+            "Type": "AWS::ECS::Service",
+            "Properties" : {
+                "Cluster": {"Ref": "speakersCluster"},
+                "DesiredCount": "1",
+                "TaskDefinition" : {"Ref":"speakerCommsTaskDefinition"}
             }
         }
     }


### PR DESCRIPTION
I've added the second service in same cluster as we currently have. It seems to be the going pattern...it even has a name: [Multiple service instance per host](http://microservices.io/patterns/deployment/multiple-services-per-host.html), granted not a very good name...