### PR TITLE
First playbook.  Last use of passwords.

### DIFF
--- a/dataCenter/ansible/README.md
+++ b/dataCenter/ansible/README.md
@@ -1,11 +1,31 @@
 
 Create the local VMs
 ------------------------
+```
 > vagrant up
+```
 
 
 Ansible mgmt node
 ------------------------
 Log in using ssh
+```
 > vagrant ssh mgmt
 $ ansible --version
+```
+
+
+Install ssh key
+------------------------
+Set us up for password-free use (i.e. generate a ssh key and install it on the nodes)
+```
+$ ssh-keygen -t rsa -b 2048
+$ ssh-keyscan auth comms sessions gateway frontend >> ~/.ssh/known_hosts
+
+$ cd /vagrant
+$ ansible-playbook nodes-ssh-addkey.yml --ask-pass
+password: isanopensecret
+
+$ ansible all -m ping
+```
+

--- a/dataCenter/ansible/ansible-hosts.ini
+++ b/dataCenter/ansible/ansible-hosts.ini
@@ -1,0 +1,6 @@
+[nodes]
+auth
+comms
+sessions
+gateway
+frontend

--- a/dataCenter/ansible/ansible.cfg
+++ b/dataCenter/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+hostfile = /vagrant/ansible-hosts.ini

--- a/dataCenter/ansible/nodes-ssh-addkey.yml
+++ b/dataCenter/ansible/nodes-ssh-addkey.yml
@@ -1,0 +1,12 @@
+- hosts: nodes
+  become_method: sudo
+  become_user: vagrant
+  gather_facts: no
+
+  tasks:
+
+  - name: install ssh key
+    authorized_key: user=vagrant
+                    key="{{ lookup('file', '/home/vagrant/.ssh/id_rsa.pub') }}"
+                    state=present
+


### PR DESCRIPTION
First Ansible:
Config points to hosts.
Hosts is one group of "nodes" to be treated all the same.
One easy playbook to remove the need to enter passwords each time.
And try to format the README.md
