### PR TITLE
apt-get pip and install docker-py

### DIFF
--- a/dataCenter/ansible/README.md
+++ b/dataCenter/ansible/README.md
@@ -46,5 +46,12 @@ $ docker ps
 $ ansible-playbook nodes-srm-docker.yml
 
 > vagrant ssh comms
-$ sudo cat /etc/default/docker
+$ cat /etc/default/docker
+```
+
+```
+$ ansible-playbook nodes-pip-docker-py.yml
+
+> vagrant ssh sessions
+$ pip list | grep docker-py
 ```

--- a/dataCenter/ansible/nodes-pip-docker-py.yml
+++ b/dataCenter/ansible/nodes-pip-docker-py.yml
@@ -1,0 +1,8 @@
+
+- hosts: nodes
+  become: yes
+  become_method: sudo
+  gather_facts: no
+
+  roles:
+    - pip-docker-py

--- a/dataCenter/ansible/roles/pip-docker-py/tasks/main.yml
+++ b/dataCenter/ansible/roles/pip-docker-py/tasks/main.yml
@@ -1,0 +1,6 @@
+
+- name: install pip
+  apt: pkg=python-pip update_cache=yes
+
+- name: pip docker-py
+  pip: name=docker-py


### PR DESCRIPTION
One playbook with one role for all nodes, installing the final dependency so we can install docker images using python.