### PR TITLE
Addition of env_TAG for AWS dev stack

### DIFF
--- a/dataCenter/ansible/README.md
+++ b/dataCenter/ansible/README.md
@@ -56,7 +56,7 @@ Auth.secrets.config
 Comms.secrets.config
 
 
-Just checkin'
+Check connectivity (and get any "add known_hosts" prompts over with)
 ------------------------
 ```
 $ ansible -i env_TAG all -m ping

--- a/dataCenter/ansible/README.md
+++ b/dataCenter/ansible/README.md
@@ -1,7 +1,15 @@
+Ansible
+========================
 
 Ansible only works on Unix, so we'll have a management VM and our nodes.
-We'll be using -i PATH to select the environment root.
 
+We'll be using -i PATH to select the environment root as suggested here:
+http://toja.io/using-host-and-group-vars-files-in-ansible/
+
+
+
+Local development
+========================
 
 Create the local VMs
 ------------------------
@@ -20,16 +28,27 @@ $ ansible --version
 
 Set us up for password-free use (i.e. generate a ssh key and install it on the nodes)
 ```
-$ ssh-keygen -t rsa -b 2048
 $ ssh-keyscan auth comms sessions gateway frontend consul master >> ~/.ssh/known_hosts
 
+$ ssh-keygen -t rsa -b 2048
 $ cd /vagrant
 $ ansible-playbook -i env_local all-ssh-addkey.yml --ask-pass
 password: isanopensecret
-
-$ ansible -i env_local all -m ping
 ```
 
+AWS
+========================
+
+You'll need a unix host to drive this.  "mgmt" will do.
+
+Create the AWS stack under cloudFormation
+Make sure the private keys for ssh to the AWS Instances are available
+Update the addresses in the env_TAG variables and inventory
+
+
+
+Go!
+========================
 
 Place the secrets files in /home/vagrant
 ------------------------
@@ -37,23 +56,35 @@ Auth.secrets.config
 Comms.secrets.config
 
 
-Prepare all (docker and docker-py)
+Just checkin'
 ------------------------
-$ ansible-playbook -i env_local all-apt-docker.yml
-$ ansible-playbook -i env_local all-pip-docker-py.yml
+```
+$ ansible -i env_TAG all -m ping
+```
 
 
-Start Consul
+Docker and docker-py are universal
 ------------------------
-$ ansible-playbook -i env_local srm-consul.yml
+$ ansible-playbook -i env_TAG all-apt-docker.yml
+$ ansible-playbook -i env_TAG all-pip-docker-py.yml
 
-Swarm Master
+Consul and Master
 ------------------------
-$ ansible-playbook -i env_local srm-master.yml
+$ ansible-playbook -i env_TAG infra-docker.yml
 
-Unleash DEV
+$ ansible-playbook -i env_TAG srm-consul.yml
+$ ansible-playbook -i env_TAG srm-master.yml
+
+Unleash Microservices
 ------------------------
-$ ansible-playbook -i env_local srm-nodes.yml
+$ ansible-playbook -i env_TAG nodes-docker-swarm.yml
+
+$ ansible-playbook -i env_TAG srm-auth.yml
+$ ansible-playbook -i env_TAG srm-comms.yml
+$ ansible-playbook -i env_TAG srm-sessions.yml
+$ ansible-playbook -i env_TAG srm-gateway.yml
+$ ansible-playbook -i env_TAG srm-frontend.yml
+
 
 Try the website.
 
@@ -63,6 +94,11 @@ Smoke tests
 ```
 > vagrant ssh consul
 $ curl http://localhost:8500/v1/kv
+```
+
+```
+> vagrant ssh master
+$ docker info
 ```
 
 ```
@@ -89,5 +125,3 @@ $ curl http://localhost:8080/sessions
 > vagrant ssh frontend
 $ curl http://localhost:8080/
 ```
-
-

--- a/dataCenter/ansible/all-apt-docker.retry
+++ b/dataCenter/ansible/all-apt-docker.retry
@@ -1,7 +1,0 @@
-auth
-comms
-consul
-frontend
-gateway
-master
-sessions

--- a/dataCenter/ansible/all-apt-docker.retry
+++ b/dataCenter/ansible/all-apt-docker.retry
@@ -1,0 +1,7 @@
+auth
+comms
+consul
+frontend
+gateway
+master
+sessions

--- a/dataCenter/ansible/env_TAG/group_vars/all.yml
+++ b/dataCenter/ansible/env_TAG/group_vars/all.yml
@@ -1,0 +1,11 @@
+
+user: "ubuntu"
+consul_address: "10.0.1.75:8500"
+
+sessionsdb_str: "SERVER=talksdev.ch20oh3elz3t.eu-west-1.rds.amazonaws.com;Database=sessions;UID=sessions;Password=;"
+auth_address: "10.0.1.143:8080"
+comms_address: "10.0.1.17:8080"
+sessions_address: "10.0.1.18:8080"
+frontend_url: "ec2-54-171-113-255.eu-west-1.compute.amazonaws.com:8080"
+gateway_url: "ec2-54-171-107-166.eu-west-1.compute.amazonaws.com:8080"
+auth_url: "ec2-54-154-205-44.eu-west-1.compute.amazonaws.com:8080"

--- a/dataCenter/ansible/env_TAG/inventory
+++ b/dataCenter/ansible/env_TAG/inventory
@@ -1,0 +1,13 @@
+
+[nodes]
+auth ansible_host=ec2-54-154-205-44.eu-west-1.compute.amazonaws.com ansible_user=ubuntu ansible_ssh_private_key_file=/home/vagrant/auth.pem
+comms ansible_host=ec2-54-154-209-151.eu-west-1.compute.amazonaws.com  ansible_user=ubuntu ansible_ssh_private_key_file=/home/vagrant/comms.pem
+sessions ansible_host=ec2-54-171-110-252.eu-west-1.compute.amazonaws.com  ansible_user=ubuntu ansible_ssh_private_key_file=/home/vagrant/sessions.pem
+gateway ansible_host=ec2-54-171-107-166.eu-west-1.compute.amazonaws.com ansible_user=ubuntu ansible_ssh_private_key_file=/home/vagrant/api-gateway.pem
+frontend ansible_host=ec2-54-171-113-255.eu-west-1.compute.amazonaws.com  ansible_user=ubuntu ansible_ssh_private_key_file=/home/vagrant/frontend.pem
+
+[master]
+master ansible_host=ec2-54-154-210-14.eu-west-1.compute.amazonaws.com ansible_user=ubuntu ansible_ssh_private_key_file=/home/vagrant/swarm-master.pem
+
+[consul]
+consul ansible_host=ec2-54-154-209-244.eu-west-1.compute.amazonaws.com ansible_user=ubuntu ansible_ssh_private_key_file=/home/vagrant/pna-consul.pem

--- a/dataCenter/ansible/env_local/group_vars/all.yml
+++ b/dataCenter/ansible/env_local/group_vars/all.yml
@@ -1,9 +1,11 @@
 
-mysqldb_str: "SERVER=talksdev.ch20oh3elz3t.eu-west-1.rds.amazonaws.com;Database=sessions;UID=sessions;Password=;"
+user: "vagrant"
+consul_address: "10.0.15.20:8500"
+
+sessionsdb_str: "SERVER=talksdev.ch20oh3elz3t.eu-west-1.rds.amazonaws.com;Database=sessions;UID=sessions;Password=;"
 auth_address: "10.0.15.11:8080"
 comms_address: "10.0.15.12:8080"
 sessions_address: "10.0.15.13:8080"
-consul_address: "10.0.15.20:8500"
 frontend_url: "http://localhost:8080"
 gateway_url: "http://localhost:9090"
 auth_url: "http://localhost:9003"

--- a/dataCenter/ansible/env_local/inventory
+++ b/dataCenter/ansible/env_local/inventory
@@ -5,6 +5,8 @@ comms
 sessions
 gateway
 frontend
+
+[master]
 master
 
 [consul]

--- a/dataCenter/ansible/infra-docker.yml
+++ b/dataCenter/ansible/infra-docker.yml
@@ -1,8 +1,8 @@
 
-- hosts: nodes
+- hosts: consul, master
   become: yes
   become_method: sudo
   gather_facts: yes
 
   roles:
-   - srm-docker-cluster
+   - srm-docker

--- a/dataCenter/ansible/nodes-docker-swarm.yml
+++ b/dataCenter/ansible/nodes-docker-swarm.yml
@@ -5,4 +5,5 @@
   gather_facts: yes
 
   roles:
+   - srm-docker-cluster
    - srm-swarm-agent

--- a/dataCenter/ansible/roles/apt-docker/tasks/main.yml
+++ b/dataCenter/ansible/roles/apt-docker/tasks/main.yml
@@ -9,4 +9,4 @@
   apt: pkg=docker-engine update_cache=yes
 
 - name: add user group
-  shell: usermod -aG docker vagrant
+  shell: usermod -aG docker {{ user }}

--- a/dataCenter/ansible/roles/srm-auth/tasks/main.yml
+++ b/dataCenter/ansible/roles/srm-auth/tasks/main.yml
@@ -4,10 +4,10 @@
     name: bristechsrm/auth
 
 - name: configure
-  template: src=Auth.config.j2 dest=/home/vagrant/Auth.config
+  template: src=Auth.config.j2 dest=/home/{{ user }}/Auth.config
 
 - name: secrets
-  copy: src=/home/vagrant/Auth.secrets.config dest=/home/vagrant/Auth.secrets.config
+  copy: src=/home/vagrant/Auth.secrets.config dest=/home/{{ user }}/Auth.secrets.config
 
 - name: start
   docker_container:
@@ -17,5 +17,5 @@
     ports:
      - "8080:8080"
     volumes:
-     - /home/vagrant/Auth.config:/service/Auth.exe.config
-     - /home/vagrant/Auth.secrets.config:/service/secrets.config
+     - /home/{{ user }}/Auth.config:/service/Auth.exe.config
+     - /home/{{ user }}/Auth.secrets.config:/service/secrets.config

--- a/dataCenter/ansible/roles/srm-comms/tasks/main.yml
+++ b/dataCenter/ansible/roles/srm-comms/tasks/main.yml
@@ -4,10 +4,10 @@
     name: bristechsrm/comms
 
 - name: configure
-  copy: src=Comms.config dest=/home/vagrant/Comms.config
+  copy: src=Comms.config dest=/home/{{ user }}/Comms.config
 
 - name: secrets
-  copy: src=/home/vagrant/Comms.secrets.config dest=/home/vagrant/Comms.secrets.config
+  copy: src=/home/vagrant/Comms.secrets.config dest=/home/{{ user }}/Comms.secrets.config
 
 - name: start
   docker_container:
@@ -17,5 +17,5 @@
     ports:
      - "8080:8080"
     volumes:
-     - /home/vagrant/Comms.config:/service/Comms.exe.config
-     - /home/vagrant/Comms.secrets.config:/service/secrets.config
+     - /home/{{ user }}/Comms.config:/service/Comms.exe.config
+     - /home/{{ user }}/Comms.secrets.config:/service/secrets.config

--- a/dataCenter/ansible/roles/srm-docker-cluster/templates/etc_default_docker_cluster.j2
+++ b/dataCenter/ansible/roles/srm-docker-cluster/templates/etc_default_docker_cluster.j2
@@ -1,4 +1,4 @@
 # Docker Upstart and SysVinit configuration file
 # {{ ansible_managed }}
 
-DOCKER_OPTS="-H tcp://{{ ansible_eth1.ipv4.address }}:2375 -H unix:///var/run/docker.sock --cluster-advertise={{ ansible_eth1.ipv4.address }}:2375 --cluster-store=consul://{{ consul_address }}"
+DOCKER_OPTS="-H tcp://{{ ansible_default_ipv4.address }}:2375 -H unix:///var/run/docker.sock --cluster-advertise={{ ansible_default_ipv4.address }}:2375 --cluster-store=consul://{{ consul_address }}"

--- a/dataCenter/ansible/roles/srm-docker/templates/etc_default_docker.j2
+++ b/dataCenter/ansible/roles/srm-docker/templates/etc_default_docker.j2
@@ -1,4 +1,4 @@
 # Docker Upstart and SysVinit configuration file
 # {{ ansible_managed }}
 
-DOCKER_OPTS="-H tcp://{{ ansible_eth0.ipv4.address }}:2375 -H unix:///var/run/docker.sock"
+DOCKER_OPTS="-H tcp://{{ ansible_default_ipv4.address }}:2375 -H unix:///var/run/docker.sock"

--- a/dataCenter/ansible/roles/srm-frontend/tasks/main.yml
+++ b/dataCenter/ansible/roles/srm-frontend/tasks/main.yml
@@ -4,7 +4,7 @@
     name: bristechsrm/frontend
 
 - name: configure
-  template: src=frontend.json.j2 dest=/home/vagrant/frontend.json
+  template: src=frontend.json.j2 dest=/home/{{ user }}/frontend.json
 
 - name: start
   docker_container:
@@ -14,4 +14,4 @@
     ports:
      - "8080:8080"
     volumes:
-     - /home/vagrant/frontend.json:/frontend/public/js/config.json
+     - /home/{{ user }}/frontend.json:/frontend/public/js/config.json

--- a/dataCenter/ansible/roles/srm-gateway/tasks/main.yml
+++ b/dataCenter/ansible/roles/srm-gateway/tasks/main.yml
@@ -4,7 +4,7 @@
     name: bristechsrm/api-gateway
 
 - name: configure
-  template: src=Gateway.config.j2 dest=/home/vagrant/Gateway.config
+  template: src=Gateway.config.j2 dest=/home/{{ user }}/Gateway.config
 
 - name: start
   docker_container:
@@ -14,4 +14,4 @@
     ports:
      - "8080:8080"
     volumes:
-     - /home/vagrant/Gateway.config:/service/ApiGateway.exe.config
+     - /home/{{ user }}/Gateway.config:/service/ApiGateway.exe.config

--- a/dataCenter/ansible/roles/srm-sessions/tasks/main.yml
+++ b/dataCenter/ansible/roles/srm-sessions/tasks/main.yml
@@ -4,7 +4,7 @@
     name: bristechsrm/sessions
 
 - name: configure
-  template: src=Sessions.config.j2 dest=/home/vagrant/Sessions.config
+  template: src=Sessions.config.j2 dest=/home/{{ user }}/Sessions.config
 
 - name: start
   docker_container:
@@ -14,4 +14,4 @@
     ports:
      - "8080:8080"
     volumes:
-     - /home/vagrant/Sessions.config:/service/Sessions.exe.config
+     - /home/{{ user }}/Sessions.config:/service/Sessions.exe.config

--- a/dataCenter/ansible/roles/srm-sessions/templates/Sessions.config.j2
+++ b/dataCenter/ansible/roles/srm-sessions/templates/Sessions.config.j2
@@ -2,7 +2,7 @@
 <configuration>
   <connectionStrings>
     <!-- Security provided by AWS security groups -->
-    <add name="DefaultConnection" connectionString="{{ mysqldb_str }}" providerName="System.Data.SqlClient"/>
+    <add name="DefaultConnection" connectionString="{{ sessionsdb_str }}" providerName="System.Data.SqlClient"/>
   </connectionStrings>
   <system.data>
     <DbProviderFactories>

--- a/dataCenter/ansible/roles/srm-swarm-agent/tasks/main.yml
+++ b/dataCenter/ansible/roles/srm-swarm-agent/tasks/main.yml
@@ -4,4 +4,4 @@
     name: swarm
 
 - name: start
-  command: docker run -d swarm join --advertise {{ ansible_eth1.ipv4.address }}:2375 consul://{{ consul_address }}
+  command: docker run -d swarm join --advertise {{ ansible_eth0.ipv4.address }}:2375 consul://{{ consul_address }}

--- a/dataCenter/ansible/srm-consul.yml
+++ b/dataCenter/ansible/srm-consul.yml
@@ -2,8 +2,7 @@
 - hosts: consul
   become: yes
   become_method: sudo
-  gather_facts: yes
+  gather_facts: no
 
   roles:
-   - srm-docker
    - srm-consul

--- a/dataCenter/ansible/srm-master.yml
+++ b/dataCenter/ansible/srm-master.yml
@@ -2,8 +2,7 @@
 - hosts: master
   become: yes
   become_method: sudo
-  gather_facts: yes
+  gather_facts: no
 
   roles:
-   - srm-docker-cluster
    - srm-swarm-master

--- a/dataCenter/ansible/srm-nodes.yml
+++ b/dataCenter/ansible/srm-nodes.yml
@@ -1,8 +1,0 @@
-
-- include: nodes-docker-cluster.yml
-- include: nodes-swarm-agent.yml
-- include: srm-auth.yml
-- include: srm-comms.yml
-- include: srm-sessions.yml
-- include: srm-gateway.yml
-- include: srm-frontend.yml


### PR DESCRIPTION
env_TAG folder added for AWS (still using talksdev)

The user has been parameterized as {{ user }}, vagrant on local VMs, ubuntu on AWS
master is no longer included among the nodes, so no swarm agent for him
vars are stored as all_vars
more individual steps, but it is clearer what they do
