### PR TITLE
Add certificate file mount, README

### DIFF
--- a/concourse/resources/dockerSwarm/Dockerfile
+++ b/concourse/resources/dockerSwarm/Dockerfile
@@ -1,5 +1,6 @@
 FROM concourse/docker-image-resource
 
 COPY ./resource /opt/resource
+
 RUN chmod +x /opt/resource/*
 

--- a/concourse/resources/dockerSwarm/README.md
+++ b/concourse/resources/dockerSwarm/README.md
@@ -1,0 +1,21 @@
+
+Docker Swarm Deploy
+===================
+
+Our Concourse pipelines use a custom resource (bristechsrm/docker-swarm-deploy) to deploy to Docker Swarm.
+The resource is in the form of a Docker image on Docker Hub.
+This Dockerfile builds that image.
+
+
+Building
+-------------------
+You need a unix box with docker installed.
+
+```
+$ docker login
+> username
+> chickens
+
+$ docker build -t bristechsrm/docker-swarm-deploy .
+$ docker push bristechsrm/docker-swarm-deploy
+```

--- a/concourse/resources/dockerSwarm/resource/out
+++ b/concourse/resources/dockerSwarm/resource/out
@@ -38,9 +38,12 @@ set -e
 
 docker pull ${repository}
 
+# This treats all nodes the same, so it is necessarily a superset
+# The extra volume mounts are harmless, if annoying
 docker run -d -p ${portNumber}:8080 --name=${serviceName} --net=${network} --env=constraint:node==${nodeName} \
     -v /home/ubuntu/prd.${executableName}.config:/service/${executableName}.exe.config \
     -v /home/ubuntu/secrets.${executableName}.config:/service/secrets.config \
+    -v /home/ubuntu/AuthCertificate.pfx:/AuthCertificate.pfx \
     ${repository}
 
 echo '{ "version": { "ref": "'$BUILD_ID'" } }' >&3


### PR DESCRIPTION
This adds the certificate file mount to the docker swarm command that concourse runs after each build.
And some instructions.
And one newline.